### PR TITLE
Add flag for sending implicit header mode packets

### DIFF
--- a/concentrate/src/app/send.rs
+++ b/concentrate/src/app/send.rs
@@ -4,6 +4,7 @@ use std::net::{SocketAddr, UdpSocket};
 
 #[allow(clippy::too_many_arguments)]
 pub fn send(
+    implicit: bool,
     listen_port: u16,
     freq: u32,
     radio: u8,
@@ -61,7 +62,7 @@ pub fn send(
         },
         invert_polarity: false,
         omit_crc: false,
-        implicit_header: false,
+        implicit_header: implicit,
         payload: payload.unwrap_or_default().into_bytes(),
         ..Default::default()
     };

--- a/concentrate/src/cmdline.rs
+++ b/concentrate/src/cmdline.rs
@@ -21,6 +21,10 @@ pub enum Cmd {
     /// 'serve' mode.
     #[structopt(name = "send")]
     Send {
+        /// Transmit with implicit header.
+        #[structopt(short = "i", long = "implicit")]
+        implicit: bool,
+
         /// Frequency to transmit packet on.
         #[structopt(value_name = "Hz", short = "f", long = "freq")]
         freq: u32,

--- a/concentrate/src/main.rs
+++ b/concentrate/src/main.rs
@@ -41,6 +41,7 @@ fn go(args: cmdline::Args) -> AppResult {
         }
         cmdline::Cmd::Listen => app::listen(args.print_level, args.publish_port),
         cmdline::Cmd::Send {
+            implicit,
             freq,
             radio,
             power,
@@ -49,6 +50,7 @@ fn go(args: cmdline::Args) -> AppResult {
             bandwidth,
             payload,
         } => app::send(
+            implicit,
             args.listen_port,
             freq,
             radio,


### PR DESCRIPTION
The machinery is already there for sending implicit headers. This PR just exposes it via a command-line flag.