### PR TITLE
Lower SPI clock speed to 1 MHz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ Feature enhancements:
 * [#10](https://github.com/helium/concentrate/pull/10):
   Add implicit header flag to `send` command.
 
+Bug fixes:
+
+* [#13](https://github.com/helium/concentrate/pull/13):
+  Lower SPI clock speed as it might be contributing to TX errors.
+
 0.1.2 (2019-06-07)
 ==================
 Feature enhancements:

--- a/libloragw-sys/vendor/libloragw/loragw_spi.native.c
+++ b/libloragw-sys/vendor/libloragw/loragw_spi.native.c
@@ -53,7 +53,7 @@ Maintainer: Sylvain Miermont
 
 #define READ_ACCESS     0x00
 #define WRITE_ACCESS    0x80
-#define SPI_SPEED       2000000
+#define SPI_SPEED       1000000
 #define SPI_DEV_PATH    "/dev/spidev0.0"
 //#define SPI_DEV_PATH    "/dev/spidev32766.0"
 


### PR DESCRIPTION
RAK forums seem to indicate that even 2 MHz might be too fast. There's a small chance that this is the reason we're dropping TX packets.