### PR TITLE
Make calls to `libloragw-sys` threadsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ Bug fixes:
   A bugfix.
 -->
 
+
+next-release
+==================
+Bug fixes:
+
+* [#18](https://github.com/helium/concentrate/pull/18):
+  Make calls to `libloragw-sys` threadsafe.
+
 0.1.7 (2019-06-26)
 ==================
 Bug fixes:


### PR DESCRIPTION
The current hurried attempt of wrapping the thread-unsafe
`libloragw-sys` is not effective. All that is needed is to:

1. Only allow a single `Concentrator` instance (already implemented
via atomics)
2. Prevent `Concentrator` from implementing `Sync` (this commit)