### PR TITLE
Update sync word for private networks to 0x16

### DIFF
--- a/libloragw-sys/vendor/libloragw/loragw_hal.c
+++ b/libloragw-sys/vendor/libloragw/loragw_hal.c
@@ -275,7 +275,7 @@ void lgw_constant_adjust(void) {
         lgw_reg_w(LGW_FRAME_SYNCH_PEAK2_POS,4); /* default 2 */
     } else { /* private network */
         lgw_reg_w(LGW_FRAME_SYNCH_PEAK1_POS,1); /* default 1 */
-        lgw_reg_w(LGW_FRAME_SYNCH_PEAK2_POS,2); /* default 2 */
+        lgw_reg_w(LGW_FRAME_SYNCH_PEAK2_POS,6); /* default 2 */
     }
 
     // lgw_reg_w(LGW_PREAMBLE_FINE_TIMING_GAIN,1); /* default 1 */
@@ -297,7 +297,7 @@ void lgw_constant_adjust(void) {
         lgw_reg_w(LGW_MBWSSF_FRAME_SYNCH_PEAK2_POS,4); /* default 2 */
     } else {
         lgw_reg_w(LGW_MBWSSF_FRAME_SYNCH_PEAK1_POS,1); /* default 1 */
-        lgw_reg_w(LGW_MBWSSF_FRAME_SYNCH_PEAK2_POS,2); /* default 2 */
+        lgw_reg_w(LGW_MBWSSF_FRAME_SYNCH_PEAK2_POS,6); /* default 2 */
     }
     // lgw_reg_w(LGW_MBWSSF_ONLY_CRC_EN,1); /* default 1 */
     // lgw_reg_w(LGW_MBWSSF_PAYLOAD_FINE_TIMING_GAIN,2); /* default 2 */
@@ -338,7 +338,7 @@ void lgw_constant_adjust(void) {
         lgw_reg_w(LGW_TX_FRAME_SYNCH_PEAK2_POS,4); /* default 2 */
     } else { /* Private network */
         lgw_reg_w(LGW_TX_FRAME_SYNCH_PEAK1_POS,1); /* default 1 */
-        lgw_reg_w(LGW_TX_FRAME_SYNCH_PEAK2_POS,2); /* default 2 */
+        lgw_reg_w(LGW_TX_FRAME_SYNCH_PEAK2_POS,6); /* default 2 */
     }
 
     /* TX FSK */


### PR DESCRIPTION
Addresses: https://app.clubhouse.io/hlm/story/3680/change-concentrate-sync-word-to-be-unique-to-helium

Will require an update to all end nodes once merged @lthiery 