### PR TITLE
Add built in self test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ Bug fixes:
   A bugfix.
 -->
 
+0.1.9 (2019-07-27)
+==================
+Feature enhancements:
+
+* [#26](https://github.com/helium/concentrate/pull/26):
+  Add built in self test.
 
 0.1.8 (2019-07-23)
 ==================

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "concentrate"
-version = "0.1.5"
+version = "0.1.9"
 dependencies = [
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/concentrate/Cargo.toml
+++ b/concentrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concentrate"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Jay Kickliter <jay@kickliter.com>"]
 
 [dependencies]

--- a/concentrate/src/app/bist.rs
+++ b/concentrate/src/app/bist.rs
@@ -1,0 +1,32 @@
+use crate::{cfg, error::AppResult, loragw};
+use std::convert::{TryFrom, TryInto};
+
+pub fn built_in_self_test() -> AppResult {
+    let concentrator = loragw::Concentrator::open()?;
+    let cfg = cfg::Config::from_str_or_default(None)?;
+
+    concentrator.config_board(&cfg.board.try_into()?)?;
+
+    if let Some(radios) = cfg.radios {
+        for c in radios {
+            concentrator.config_rx_rf(&loragw::RxRFConf::try_from(c)?)?;
+        }
+    }
+
+    if let Some(multirate_channels) = cfg.multirate_channels {
+        for (i, c) in multirate_channels.iter().enumerate() {
+            concentrator.config_channel(i as u8, &loragw::ChannelConf::try_from(c)?)?;
+        }
+    }
+
+    if let Some(gains) = cfg.tx_gains {
+        let gains: Vec<loragw::TxGain> = gains
+            .iter()
+            .map(|g| loragw::TxGain::from(g.clone()))
+            .collect();
+        concentrator.config_tx_gain(gains.as_slice())?
+    }
+
+    concentrator.start()?;
+    Ok(())
+}

--- a/concentrate/src/app/mod.rs
+++ b/concentrate/src/app/mod.rs
@@ -3,10 +3,12 @@ use protobuf::Message;
 use std::fmt;
 use std::net::{SocketAddr, UdpSocket};
 
+mod bist;
 mod listen;
 mod send;
 mod serve;
 
+pub use self::bist::*;
 pub use self::listen::*;
 pub use self::send::*;
 pub use self::serve::*;

--- a/concentrate/src/cmdline.rs
+++ b/concentrate/src/cmdline.rs
@@ -62,6 +62,11 @@ pub enum Cmd {
         /// String payload.
         payload: Option<String>,
     },
+
+    /// Built In Self Test. Configures, starts, then immediately stops
+    /// concentrator. Returns 1 on hardware failure.
+    #[structopt(name = "bist")]
+    Bist,
 }
 
 #[derive(StructOpt)]

--- a/concentrate/src/main.rs
+++ b/concentrate/src/main.rs
@@ -96,6 +96,7 @@ fn go(args: cmdline::Args) -> AppResult {
             bandwidth,
             payload,
         ),
+        cmdline::Cmd::Bist => app::built_in_self_test(),
     }
 }
 


### PR DESCRIPTION
This PR adds a new `concentrate` subcommand, `bist` (Built In Self Test):

- Loads default config onto SX1301
- Starts the SX1301
- Exits with 0 (ok) or 1 (error)