### PR TITLE
Do not rebuild `messages` if protos have not changed

### DIFF
--- a/messages/build.rs
+++ b/messages/build.rs
@@ -1,8 +1,8 @@
 extern crate protobuf_codegen_pure;
 
 fn main() {
-    println!("cargo:rerun-if-changed=proto/longfi.proto");
-    println!("cargo:rerun-if-changed=proto/radio.proto");
+    println!("cargo:rerun-if-changed=proto/src/longfi.proto");
+    println!("cargo:rerun-if-changed=proto/src/radio.proto");
 
     protobuf_codegen_pure::run(protobuf_codegen_pure::Args {
         out_dir: "src",


### PR DESCRIPTION
Protos moved to submodule, but the build script still expects the old location. This causes `messages` to always do codegen and build. It's not terribly on amd64, but it's very slow when building natively on an arm target.