### PR TITLE
take timestamp, snr, rssi from first fragment

### DIFF
--- a/longfi-hotspot/src/longfi_parser.rs
+++ b/longfi-hotspot/src/longfi_parser.rs
@@ -112,9 +112,9 @@ impl LongFiParser {
                     mac: (u16::from(pkt.payload[9])) | (u16::from(pkt.payload[10])) << 8,
                     payload,
                     quality,
-                    timestamp: 0,
-                    snr: 0.0,
-                    rssi: 0.0,
+                    timestamp: pkt.timestamp,
+                    snr: pkt.snr,
+                    rssi: pkt.rssi,
                     spreading: pkt.spreading.into(),
                     crc_fails: 0,
                 }


### PR DESCRIPTION
Rather than doing a bad solution to timestamp/snr/rssi readings in fragmented packets, I did a no solution. This does a bad solution. 

RSSI, SNR & Timetsamp of a multifragment packet are taken from the first fragment.

In the future, might be nice to average RSSI and SNR. I do think @Vagabond requested first fragment timestamp though.