### PR TITLE
Bump package version to 0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concentrate"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2018"
 authors = ["Jay Kickliter <jay@kickliter.com>", "Louis Thiery <louis@helium.com>"]
 


### PR DESCRIPTION
Attempting to fix the following bug.

```
# concentrate --version
concentrate 0.2.3
```