### PR TITLE
Fix git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	branch = master
 [submodule "lfc-sys/longfi-core"]
 	path = lfc-sys/longfi-core
-	url = https://github.com:helium/longfi-core.git
+	url = https://github.com/helium/longfi-core.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	branch = master
 [submodule "lfc-sys/longfi-core"]
 	path = lfc-sys/longfi-core
-	url = git@github.com:helium/longfi-core.git
+	url = https://github.com:helium/longfi-core.git


### PR DESCRIPTION
For some reason, the ssh path for the git submodules broke when we went from closed to open. This uses https instead.