### PR TITLE
Add tag bits to proto message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Bug fixes:
   A bugfix.
 -->
 
+0.2.5 (2019-11-07)
+==================
+Feature enhancements:
+
+* [#45](https://github.com/helium/concentrate/pull/45):
+  Add tag bits to proto message.
+
 0.2.4 (2019-10-01)
 ==================
 Bug fixes:

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20,10 +20,10 @@ pub use self::send::*;
 pub use self::serve::*;
 
 fn print_at_level<T: fmt::Debug>(print_level: u8, pkt: &T) {
-    if print_level > 1 {
-        println!("{:#?}\n", pkt);
-    } else if print_level == 1 {
-        println!("{:?}\n", pkt);
+    match print_level {
+        0 => (),
+        1 => println!("{:?}\n", pkt),
+        _ => println!("{:#?}\n", pkt),
     }
 }
 


### PR DESCRIPTION
Adding raw tag bits to the proto message allows routers to verify fingerprints.

This PR needs to helium/protos to merge first.

# Needed

- [x] helium/proto/pull/8 needs to land first
- [x] point this repo's submodule to proto after the above lands
- [ ] (optional) `longfi-core` is being updated in helium/longfi-core/pull/18. not needed for this PR, but maybe worth waiting for it to land.