### PR TITLE
Allow runtime choice of logging backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Bug fixes:
   A bugfix.
 -->
 
+0.2.9 (2019-11-27)
+==================
+Feature enhancements:
+
+* [#48](https://github.com/helium/concentrate/pull/48):
+  Allow runtime choice of logging backend.
+
 0.2.8 (2019-11-26)
 ==================
 Housekeeping:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "concentrate"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concentrate"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2018"
 authors = ["Jay Kickliter <jay@kickliter.com>", "Louis Thiery <louis@helium.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,9 @@ rand = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 structopt = "0.2.15"
 toml = "=0.5.0"
-
-[dependencies.syslog]
-version = "4"
-optional = true
-
-[dependencies.env_logger]
-version = "0.6.1"
-optional = true
-
-[dependencies.log-panics]
-version = "2.0.0"
-optional = true
+env_logger = "0.6.1"
+syslog = "4"
+log-panics = "2"
 
 # NOTE: configuring concentrate's hardware support (SX1301
 # v.s. SX1302) is not ideal. In fact, it's pretty horrible. Ideally,
@@ -37,9 +28,6 @@ optional = true
 # libraries' ecessive use of non fake-namespaced c globals. We still
 # have other options, and will revisit those options in the future.
 [features]
-default = ["log_sys"]
-log_env = ["env_logger", "log-panics"]
-log_sys = ["syslog", "log-panics"]
 sx1301  = ["loragw/sx1301"]
 sx1302  = ["loragw/sx1302"]
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,6 @@ concentrate -p listen
 ```
 
 ### Notes
-To build with `log_env`:
-```
-~/concentrate/concentrate$ cargo build --no-default-features --features log_env
-```
 
 For 10.76.100.10: 
 ```


### PR DESCRIPTION
Currently, the choice between syslog and console logging is a compile-time feature flag. Often times when we need more detailed logging it's beneficial to temporarily run with console logging via setting the `CONCENTRATE_LOG` environment variable. This PR removes those feature flags and enables both backends, if `CONCENTRATE_LOG` is set, we initialize `env_logger`, otherwise we initialize the `syslog` backend.